### PR TITLE
Feature/skip and log errors

### DIFF
--- a/gh_user_event_fetcher.go
+++ b/gh_user_event_fetcher.go
@@ -286,12 +286,18 @@ func (guef GoGithubUserEventFetcher) FetchCommitsForPushEvent(
 		// "tleyden/keynuker" -> ["tleyden", "keynuker"] -> "keynuker"
 		repoNameAndUsername := *userEvent.Repo.Name
 		repoNameAndUsernameComponents := strings.Split(repoNameAndUsername, "/")
-		username := repoNameAndUsernameComponents[0]
-		repoName := repoNameAndUsernameComponents[1]
+		oldusername := repoNameAndUsernameComponents[0]
+		oldRepoName := repoNameAndUsernameComponents[1]
+		log.Printf("oldusername: %v, oldRepoName: %v", oldusername, oldRepoName)
+		log.Printf("pushEvent.Repo: %+v", pushEvent.Repo)
+
+		owner := *pushEvent.Repo.Owner.Name
+		repoName := *pushEvent.Repo.Name
+		log.Printf("owner: %v, repoName: %v", owner, repoName)
 
 		additionalCommits, resp, err := guef.ApiClient.Repositories.ListCommits(
 			ctx,
-			*userEvent.Actor.Login,
+			owner,
 			repoName,
 			commitListOptions,
 		)
@@ -311,7 +317,7 @@ func (guef GoGithubUserEventFetcher) FetchCommitsForPushEvent(
 			// Call GetCommit() to get the patch content of the commit, as long as it's < 1 MB.
 			repoCommit, _, err := guef.ApiClient.Repositories.GetCommit(
 				ctx,
-				username,
+				owner,
 				repoName,
 				*additionalCommit.SHA,
 			)
@@ -329,7 +335,7 @@ func (guef GoGithubUserEventFetcher) FetchCommitsForPushEvent(
 
 					blob, _, err := guef.ApiClient.Git.GetBlob(
 						ctx,
-						username,
+						owner,
 						repoName,
 						*repoCommitFile.SHA,
 					)

--- a/gh_user_event_fetcher.go
+++ b/gh_user_event_fetcher.go
@@ -215,7 +215,8 @@ func (guef GoGithubUserEventFetcher) FetchDownstreamContent(ctx context.Context,
 			// Fetch the rest of the commits for this push event and append downstream content to buffer
 			_, err := guef.FetchCommitsForPushEvent(ctx, userEvent, v, &buffer)
 			if err != nil {
-				return nil, fmt.Errorf("Error fetching additional commits for push event: %v.  Error: %v", *v.PushID, err)
+				log.Printf("Warning: Error fetching additional commits for push event: %v.  Error: %v", *v.PushID, err)
+				return nil, err
 			}
 
 		}

--- a/gh_user_event_fetcher.go
+++ b/gh_user_event_fetcher.go
@@ -282,17 +282,18 @@ func (guef GoGithubUserEventFetcher) FetchCommitsForPushEvent(
 			},
 		}
 		log.Printf("Listing additional commits: %+v", commitListOptions)
+		log.Printf("userEvent.Repo: %+v", userEvent.Repo)
 
 		// "tleyden/keynuker" -> ["tleyden", "keynuker"] -> "keynuker"
 		repoNameAndUsername := *userEvent.Repo.Name
 		repoNameAndUsernameComponents := strings.Split(repoNameAndUsername, "/")
-		oldusername := repoNameAndUsernameComponents[0]
-		oldRepoName := repoNameAndUsernameComponents[1]
-		log.Printf("oldusername: %v, oldRepoName: %v", oldusername, oldRepoName)
-		log.Printf("pushEvent.Repo: %+v", pushEvent.Repo)
+		owner := repoNameAndUsernameComponents[0]
+		repoName := repoNameAndUsernameComponents[1]
+		//log.Printf("oldusername: %v, oldRepoName: %v", oldusername, oldRepoName)
+		//log.Printf("pushEvent.Repo: %+v", pushEvent.Repo)
 
-		owner := *pushEvent.Repo.Owner.Name
-		repoName := *pushEvent.Repo.Name
+		//owner := *userEvent.Repo.Owner.Name
+		//repoName := *userEvent.Repo.Name
 		log.Printf("owner: %v, repoName: %v", owner, repoName)
 
 		additionalCommits, resp, err := guef.ApiClient.Repositories.ListCommits(

--- a/gh_user_event_fetcher.go
+++ b/gh_user_event_fetcher.go
@@ -281,20 +281,13 @@ func (guef GoGithubUserEventFetcher) FetchCommitsForPushEvent(
 				Page:    resultPage,
 			},
 		}
-		log.Printf("Listing additional commits: %+v", commitListOptions)
-		log.Printf("userEvent.Repo: %+v", userEvent.Repo)
+		log.Printf("Listing additional commits: %+v for repo: %s", commitListOptions, *userEvent.Repo.Name)
 
 		// "tleyden/keynuker" -> ["tleyden", "keynuker"] -> "keynuker"
 		repoNameAndUsername := *userEvent.Repo.Name
 		repoNameAndUsernameComponents := strings.Split(repoNameAndUsername, "/")
 		owner := repoNameAndUsernameComponents[0]
 		repoName := repoNameAndUsernameComponents[1]
-		//log.Printf("oldusername: %v, oldRepoName: %v", oldusername, oldRepoName)
-		//log.Printf("pushEvent.Repo: %+v", pushEvent.Repo)
-
-		//owner := *userEvent.Repo.Owner.Name
-		//repoName := *userEvent.Repo.Name
-		log.Printf("owner: %v, repoName: %v", owner, repoName)
 
 		additionalCommits, resp, err := guef.ApiClient.Repositories.ListCommits(
 			ctx,

--- a/github_user_events_scanner.go
+++ b/github_user_events_scanner.go
@@ -51,6 +51,15 @@ func (s *ScanResult) SetCheckpointIfMostRecent(latestEventScanned *github.Event)
 
 }
 
+func (s *ScanResult) SetDefaultResultCheckpoint(user *github.User, checkpoints GithubEventCheckpoints) {
+
+	checkpoint, ok := checkpoints.CheckpointForUser(user)
+	if ok {
+		s.SetCheckpointIfMostRecent(checkpoint)
+	}
+
+}
+
 // Return a compact (stripped) version of the checkpoint event that has the minimal
 // fields to still be useful
 func (s ScanResult) CompactCheckpointEvent() *github.Event {
@@ -174,6 +183,12 @@ func (gues GithubUserEventsScanner) scanAwsKeysForUser(ctx context.Context, user
 	log.Printf("ScanGithubUserEventsForAwsKeys for user: %v", *user.Login)
 
 	scanResult.User = user
+
+	// It's better to return the existing checkpoint rather than an empty checkpoint,
+	// since an empty checkpoint will clobber what's in the database and cause it to revert to
+	// a time-based checkpoint 24 hours ago.  So set the scanResult checkpoint to the current
+	// checkpoint for that user.
+	scanResult.SetDefaultResultCheckpoint(user, params.GithubEventCheckpoints)
 
 	fetchUserEventsInput := params.CreateFetchUserEventsInput(user)
 

--- a/github_user_events_scanner.go
+++ b/github_user_events_scanner.go
@@ -140,13 +140,13 @@ func (gues GithubUserEventsScanner) ScanAwsKeys(params ParamsScanGithubUserEvent
 		defer collectedResultsWaitGroup.Done()
 		for scanResult := range chScanResults {
 
+			githubEventCheckpoints[*scanResult.User.Login] = scanResult.CompactCheckpointEvent()
+
 			// TODO: partial errors are being absorbed/ignored here.  They should somehow be propagated back to the caller
 			if scanResult.Error != nil {
 				log.Printf("Warning: Got error trying to scan github user events: %+v", scanResult)
 				continue
 			}
-
-			githubEventCheckpoints[*scanResult.User.Login] = scanResult.CompactCheckpointEvent()
 
 			leakedKeyEvents = append(leakedKeyEvents, scanResult.LeakedKeyEvents...)
 		}


### PR DESCRIPTION
Fixes two issues:

1. Was getting 404s because it was using the commit api with the user being scanned rather than the repo owner 
2. In the case of 404 errors, it was previously aborting with an error, and it could never progress.  Now even with the error from 1. in place, it will behave better:
    - If it's a rate error, it will treat as temporary and throw an error and not advance the checkpoint (uh, actually it might return an empty checkpoint in this case, which will clobber existing checkpoint with an empty checkpoint, which will then cause it to look 24 hours back -- this should get fixed)
    - Otherwise, if it's a permanent error, it will log a warning and advance the checkpoint.