### PR TITLE
Feature/reduce abuse detection

### DIFF
--- a/gh_user_event_fetcher.go
+++ b/gh_user_event_fetcher.go
@@ -83,11 +83,8 @@ func (guef GoGithubUserEventFetcher) FetchUserEvents(ctx context.Context, fetchU
 	eventStack := NewEventStack()
 
 	// Loop over all pages returned by API and accumulate events
-	// TODO: #1 needs to also collect github gists
-	// TODO: #2 filter out any events that aren't in EventTypesToInclude
-	// TODO: #3 the code to loop over all pages could be extracted out into a re-usable wrappr function
-	// TODO: #4 what should publicOnly be set to?  Seems like it depends on the permissions of the accesstoken
-	// TODO:    and it would be good to grab private events if the access token gives enough permissions
+
+	// TODO: #1 It can stop going back if the oldest event from the most recent page of results is older than the checkpoint event.
 
 	for {
 

--- a/github_user_events_scanner.go
+++ b/github_user_events_scanner.go
@@ -171,6 +171,14 @@ func (gues GithubUserEventsScanner) ScanAwsKeys(params ParamsScanGithubUserEvent
 			break
 		}
 
+		// desperate attempt to have the process avoid blowing up with memory usage, since if it blows up in memory it will
+		// fail to return the checkpoints, and get stuck in a death spiral.  The deeper fix is to have it avoid using
+		// so much memory in the first place.
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		if m.Alloc > keynuker_go_common.HighWatermarkHeapSizeBytes {
+			runtime.GC()
+		}
 
 	}
 

--- a/github_user_events_scanner.go
+++ b/github_user_events_scanner.go
@@ -169,14 +169,6 @@ func (gues GithubUserEventsScanner) ScanAwsKeys(params ParamsScanGithubUserEvent
 			break
 		}
 
-		// ensure that the heap size is not getting too large, since if it blows up in memory it will
-		// fail to return the checkpoints, and get stuck in a death spiral
-		var m runtime.MemStats
-		runtime.ReadMemStats(&m)
-		if m.Alloc > keynuker_go_common.HighWatermarkHeapSizeBytes {
-			log.Printf("Warning: Current allocated heap (%d) over high watermark (%d) for memory usage.  Returning current results so far", m.Alloc, keynuker_go_common.HighWatermarkHeapSizeBytes)
-			break
-		}
 
 	}
 

--- a/github_user_events_scanner.go
+++ b/github_user_events_scanner.go
@@ -11,8 +11,6 @@ import (
 
 	"strings"
 
-	"runtime"
-
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -169,15 +167,6 @@ func (gues GithubUserEventsScanner) ScanAwsKeys(params ParamsScanGithubUserEvent
 		if time.Since(startTime) > keynuker_go_common.HighWatermarkExecutionSeconds {
 			log.Printf("Warning: over high watermark for action exuction time limit.  Returning current results so far")
 			break
-		}
-
-		// desperate attempt to have the process avoid blowing up with memory usage, since if it blows up in memory it will
-		// fail to return the checkpoints, and get stuck in a death spiral.  The deeper fix is to have it avoid using
-		// so much memory in the first place.
-		var m runtime.MemStats
-		runtime.ReadMemStats(&m)
-		if m.Alloc > keynuker_go_common.HighWatermarkHeapSizeBytes {
-			runtime.GC()
 		}
 
 	}

--- a/github_user_events_scanner_test.go
+++ b/github_user_events_scanner_test.go
@@ -117,13 +117,13 @@ func TestScanGithubUserEventsForAwsKeys(t *testing.T) {
 				mockGithubEvent1 = &github.Event{
 					Type:       aws.String("PushEvent"),
 					ID:         aws.String("mockGithubEvent1"),
-					CreatedAt:  aws.Time(time.Now()),
+					CreatedAt:  aws.Time(time.Now().Add(time.Minute * -5)),
 					RawPayload: &rawPayload, // not used except to satisfy go-github parser
 				}
 				mockGithubEvent2 = &github.Event{
 					Type:       aws.String("PushEvent"),
 					ID:         aws.String("mockGithubEvent2"),
-					CreatedAt:  aws.Time(time.Now()),
+					CreatedAt:  aws.Time(time.Now().Add(time.Minute * -10)),
 					RawPayload: &rawPayload, // not used except to satisfy go-github parser
 				}
 				mockGithubEvent3 = &github.Event{ // this event will be ignored since it's 24 hours before than checkpoint
@@ -236,7 +236,7 @@ func TestScanGithubUserEventsForAwsKeys(t *testing.T) {
 		assert.Equal(t, *docWrapper.LeakedKeyEvents[0].GithubEvent.ID, *mockGithubEvent1.ID)
 		assert.Equal(t, "testuser@gmail.com", docWrapper.LeakedKeyEvents[0].LeakerEmail)
 		assert.True(t, len(docWrapper.GithubEventCheckpoints) == 3)
-		assert.Equal(t, *docWrapper.GithubEventCheckpoints[*githubUser.Login].ID, *mockGithubEvent2.ID)
+		assert.Equal(t, *docWrapper.GithubEventCheckpoints[*githubUser.Login].ID, *mockGithubEvent1.ID)
 
 		// The user with actual events should have a non-nil checkpoint
 		assert.NotNil(t, docWrapper.GithubEventCheckpoints[*githubUser.Login])

--- a/github_user_events_scanner_test.go
+++ b/github_user_events_scanner_test.go
@@ -236,7 +236,7 @@ func TestScanGithubUserEventsForAwsKeys(t *testing.T) {
 		assert.Equal(t, *docWrapper.LeakedKeyEvents[0].GithubEvent.ID, *mockGithubEvent1.ID)
 		assert.Equal(t, "testuser@gmail.com", docWrapper.LeakedKeyEvents[0].LeakerEmail)
 		assert.True(t, len(docWrapper.GithubEventCheckpoints) == 3)
-		assert.Equal(t, *docWrapper.GithubEventCheckpoints[*githubUser.Login].ID, *mockGithubEvent1.ID)
+		assert.Equal(t, *mockGithubEvent1.ID, *docWrapper.GithubEventCheckpoints[*githubUser.Login].ID)
 
 		// The user with actual events should have a non-nil checkpoint
 		assert.NotNil(t, docWrapper.GithubEventCheckpoints[*githubUser.Login])

--- a/install.py
+++ b/install.py
@@ -21,6 +21,9 @@ def main():
     # Installs openwhisk actions via wsk utility to your configured OpenWhisk system
     install_openwhisk_actions(packaging_params)
 
+    # Update openwhisk actions with No-op update in order to re-trigger docker pull
+    no_op_update_openwhisk_actions(packaging_params)
+
     print("Success!")
 
 def build_binaries(packaging_params):
@@ -165,6 +168,23 @@ def verify_openwhisk_actions_env_variables(packaging_params):
         print("Verifying env variables for OpenWhisk action for path: {}".format(path))
         packaging_params.path = path
         verify_openwhisk_action_env_variables_in_path(action_params_to_env, path)
+
+
+def no_op_update_openwhisk_actions(packaging_params):
+
+    action_params_to_env = get_action_params_to_env()
+
+    for openwhisk_action, params in action_params_to_env:
+
+        command = "wsk action update {}".format(
+            openwhisk_action
+        )
+
+        print("Updating OpenWhisk action via {}".format(command))
+        if packaging_params.dryRun is True:
+            return
+
+        subprocess.check_call(command, shell=True)
 
 
 def install_openwhisk_actions(packaging_params):

--- a/install.py
+++ b/install.py
@@ -174,7 +174,7 @@ def no_op_update_openwhisk_actions(packaging_params):
 
     action_params_to_env = get_action_params_to_env()
 
-    for openwhisk_action, params in action_params_to_env:
+    for openwhisk_action in action_params_to_env:
 
         command = "wsk action update {}".format(
             openwhisk_action

--- a/keynuker-go-common/constants.go
+++ b/keynuker-go-common/constants.go
@@ -77,13 +77,7 @@ const (
 
 	// The high watermark at which point an action should be aborted since approaching max
 	HighWatermarkExecutionSeconds = MaxActionExecutionSeconds - (time.Second * 30)
-
-	// The approximate max heap size before the action will be killed by the platform.
-	MaxHeapSizeBytes = 512000000
-
-	// The heap size at which it tries to do a clean exit and abort (but push checkpoints forward)
-	HighWatermarkHeapSizeBytes = MaxHeapSizeBytes / 3
-
+	
 )
 
 var (

--- a/keynuker-go-common/constants.go
+++ b/keynuker-go-common/constants.go
@@ -54,7 +54,6 @@ const (
 	EnvVarKeyNukerMailerApiKey = "KEYNUKER_MAILER_API_KEY"
 
 	EnvVarKeyNukerMailerPublicApiKey = "KEYNUKER_MAILER_PUBLIC_API_KEY"
-
 )
 
 // Misc
@@ -77,13 +76,6 @@ const (
 
 	// The high watermark at which point an action should be aborted since approaching max
 	HighWatermarkExecutionSeconds = MaxActionExecutionSeconds - (time.Second * 30)
-
-	// The approximate max heap size before the action will be killed by the platform.
-	MaxHeapSizeBytes = 512000000
-
-	// The heap size at which it tries to do a clean exit and abort (but push checkpoints forward)
-	HighWatermarkHeapSizeBytes = MaxHeapSizeBytes / 3
-
 )
 
 var (
@@ -94,6 +86,5 @@ var (
 
 func init() {
 	DefaultCheckpointEventTimeWindow = time.Hour * -12
-
 
 }

--- a/keynuker-go-common/constants.go
+++ b/keynuker-go-common/constants.go
@@ -77,7 +77,13 @@ const (
 
 	// The high watermark at which point an action should be aborted since approaching max
 	HighWatermarkExecutionSeconds = MaxActionExecutionSeconds - (time.Second * 30)
-	
+
+	// The approximate max heap size before the action will be killed by the platform.
+	MaxHeapSizeBytes = 512000000
+
+	// The heap size at which it tries to do a clean exit and abort (but push checkpoints forward)
+	HighWatermarkHeapSizeBytes = MaxHeapSizeBytes / 3
+
 )
 
 var (

--- a/keynuker-go-common/constants.go
+++ b/keynuker-go-common/constants.go
@@ -72,6 +72,12 @@ const (
 	// This should be raised to 100 MB once the stream based scanning is implemented.
 	MaxSizeBytesBlobContent = 10000000 // 10 MB
 
+	// The max execution time for an action in seconds
+	MaxActionExecutionSeconds = time.Second * 300
+
+	// The high watermark at which point an action should be aborted since approaching max
+	HighWatermarkExecutionSeconds = MaxActionExecutionSeconds - (time.Second * 30)
+
 )
 
 var (

--- a/keynuker-go-common/constants.go
+++ b/keynuker-go-common/constants.go
@@ -78,6 +78,12 @@ const (
 	// The high watermark at which point an action should be aborted since approaching max
 	HighWatermarkExecutionSeconds = MaxActionExecutionSeconds - (time.Second * 30)
 
+	// The approximate max heap size before the action will be killed by the platform.
+	MaxHeapSizeBytes = 512000000
+
+	// The heap size at which it tries to do a clean exit and abort (but push checkpoints forward)
+	HighWatermarkHeapSizeBytes = MaxHeapSizeBytes / 3
+
 )
 
 var (


### PR DESCRIPTION

- Remove concurrency when hitting github api, to prevent abuse detection warnings
- Update actions when deploying, which should re-trigger docker pull
- Fix dev issue where it wasn't emitting all checkpoints.  Now the checkpoints are initialized to the starting checkpoints 