### PR TITLE
Feature/use bx wsk

### DIFF
--- a/docs/install.adoc
+++ b/docs/install.adoc
@@ -188,13 +188,13 @@ The `install.py` script will do the following things:
 
 ```
 $ cd $GOPATH/src/github.com/tleyden/keynuker/
-$ python install.py
+$ python install.py --bluemix
 ```
 
 Congrats!  KeyNuker is now installed.  You can do a quick verification by running `wsk action list`, which should return a list of actions:
 
 ```
-$ wsk action list
+$ bx wsk action list
 actions
 /yourusername_dev/github-user-events-scanner-nuker                     private sequence
 /yourusername_dev/fetch-aws-keys-write-doc                             private sequence

--- a/install.py
+++ b/install.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument('--bluemix', action='store_true', help='Deploy to IBM Cloud (bluemix)')
     args = parser.parse_args()
     if args.bluemix:
+        global WSK_CMD
         WSK_CMD = "bx wsk"
         print("Deploying to IBM Bluemix using the bx wsk command")
     else:

--- a/install.py
+++ b/install.py
@@ -7,11 +7,24 @@ import subprocess
 import os
 import collections
 import shutil
+import argparse
 
 KEYNUKER_ALARM_TRIGGER = "keynukerAlarmTrigger"
 KEYNUKER_WEEKLY_ALARM_TRIGGER = "keynukerWeelyAlarmTrigger"
 
+# This is the command to use to invoke the "wsk" CLI utility for interacting with OpenWhisk
+WSK_CMD = "wsk"
+
 def main():
+
+    parser = argparse.ArgumentParser(description='Deploy KeyNuker to OpenWhisk')
+    parser.add_argument('--bluemix', action='store_true', help='Deploy to IBM Cloud (bluemix)')
+    args = parser.parse_args()
+    if args.bluemix:
+        WSK_CMD = "bx wsk"
+        print("Deploying to IBM Bluemix using the bx wsk command")
+    else:
+        print("Deploying to OpenWhisk using the wsk command")
 
     packaging_params = get_default_packaging_params()
 
@@ -186,7 +199,8 @@ def no_op_update_openwhisk_actions(packaging_params):
 
     for openwhisk_action in action_params_to_env:
 
-        command = "wsk action update {}".format(
+        command = "{} action update {}".format(
+            WSK_CMD,
             openwhisk_action
         )
 
@@ -284,7 +298,8 @@ def install_openwhisk_action_sequences(available_actions):
         comma_delimited_actions = ",".join(actions)
 
         # Default the action timeout to 5 minutes, which is the max value on the hosted IBM bluemix platform
-        command = "wsk action create {} --timeout 300000 --sequence {}".format(
+        command = "{} action create {} --timeout 300000 --sequence {}".format(
+            WSK_CMD,
             action_sequence,
             comma_delimited_actions,
         )
@@ -372,7 +387,8 @@ def install_openwhisk_alarm_triggers():
         if openwhisk_trigger_exists(alarm_trigger):
             delete_openwhisk_trigger(alarm_trigger)
         
-        command = "wsk trigger create {} --feed /whisk.system/alarms/alarm --param cron '{}'".format(
+        command = "{} trigger create {} --feed /whisk.system/alarms/alarm --param cron '{}'".format(
+            WSK_CMD,
             alarm_trigger,
             schedule,
         )
@@ -415,7 +431,8 @@ def install_openwhisk_rules(available_sequences, available_actions):
         if openwhisk_rule_exists(rule):
             delete_openwhisk_rule(rule)
         
-        command = "wsk rule create {} {} {}".format(
+        command = "{} rule create {} {} {}".format(
+            WSK_CMD,
             rule,
             trigger,
             action,
@@ -426,19 +443,22 @@ def install_openwhisk_rules(available_sequences, available_actions):
 
 
 def delete_openwhisk_action(openwhisk_action):
-    command = "wsk action delete {}".format(
+    command = "{} action delete {}".format(
+        WSK_CMD,
         openwhisk_action,
     )
     subprocess.check_call(command, shell=True)
 
 def delete_openwhisk_trigger(openwhisk_trigger):
-    command = "wsk trigger delete {}".format(
+    command = "{} trigger delete {}".format(
+        WSK_CMD,
         openwhisk_trigger,
     )
     subprocess.check_call(command, shell=True)
 
 def delete_openwhisk_rule(openwhisk_rule):
-    command = "wsk rule delete {}".format(
+    command = "{} rule delete {}".format(
+        WSK_CMD,
         openwhisk_rule,
     )
     subprocess.check_call(command, shell=True)
@@ -450,7 +470,8 @@ def install_openwhisk_action(packaging_params, openwhisk_action, params_to_env):
 
     if packaging_params.useDockerSkeleton == True:
         # Default the action timeout to 5 minutes, which is the max value on the hosted IBM bluemix platform
-        command = "wsk action create {} --memory 512 --timeout 300000 --docker tleyden5iwx/openwhisk-dockerskeleton action.zip {}".format(
+        command = "{} action create {} --memory 512 --timeout 300000 --docker tleyden5iwx/openwhisk-dockerskeleton action.zip {}".format(
+            WSK_CMD,
             openwhisk_action,
             expanded_params,
         )
@@ -459,7 +480,8 @@ def install_openwhisk_action(packaging_params, openwhisk_action, params_to_env):
         build_docker_in_path(packaging_params)
 
         # Default the action timeout to 5 minutes, which is the max value on the hosted IBM bluemix platform
-        command = "wsk action create {} --memory 512 --timeout 300000 --docker {}/{}:{} {}".format(
+        command = "{} action create {} --memory 512 --timeout 300000 --docker {}/{}:{} {}".format(
+            WSK_CMD,
             openwhisk_action,
             discover_dockerhub_user(),
             openwhisk_action,
@@ -562,19 +584,22 @@ def update_openwhisk_action(openwhisk_action, params_to_env):
     raise Exception("Not implemented")
 
 def openwhisk_action_exists(openwhisk_action):
-    command = "wsk action get {} parameters".format(
+    command = "{} action get {} parameters".format(
+        WSK_CMD,
         openwhisk_action,
     )
     return subprocess.call(command, shell=True) == 0
 
 def openwhisk_trigger_exists(openwhisk_trigger):
-    command = "wsk trigger get {}".format(
+    command = "{} trigger get {}".format(
+        WSK_CMD,
         openwhisk_trigger,
     )
     return subprocess.call(command, shell=True) == 0
 
 def openwhisk_rule_exists(openwhisk_rule):
-    command = "wsk rule get {}".format(
+    command = "{} rule get {}".format(
+        WSK_CMD,
         openwhisk_rule,
     )
     return subprocess.call(command, shell=True) == 0


### PR DESCRIPTION
To deploy to IBM Cloud, add the `--bluemix` argument when running `python install.py`

Also, to deploy without including the alarm triggers (aka "dev mode"), add the `--dev` argument when running `python install.py` (todo: document this)