### PR TITLE
Fixing the Scenerio when github_event_checkpoints_default document doesn't exists

### DIFF
--- a/lookup_github_users_aws_keys.go
+++ b/lookup_github_users_aws_keys.go
@@ -79,16 +79,16 @@ func LookupGithubUsersAwsKeys(params ParamsLookupGithubUsersAwsKeys) (docWrapper
 	)
 	rowGithubEventCheckpoints := db.Get(ctx, docIdGithubEventCheckpoints, options)
 
-	if rowGithubEventCheckpoints != nil {
-		docGithubEventCheckpoints := DocumentWithGithubEventCheckpoints{}
+	docGithubEventCheckpoints := DocumentWithGithubEventCheckpoints{}
+
+	if rowGithubEventCheckpoints.Err == nil {
 		if err := rowGithubEventCheckpoints.ScanDoc(&docGithubEventCheckpoints); err != nil {
 			return docWrapper, err
 		}
-		docWrapper.GithubEventCheckpoints = docGithubEventCheckpoints.GithubEventCheckpoints
 	}
 
+	docWrapper.GithubEventCheckpoints = docGithubEventCheckpoints.GithubEventCheckpoints
 	return docWrapper, nil
-
 }
 
 type ParamsLookupGithubUsersAwsKeys struct {


### PR DESCRIPTION
* Handles the case when `github_event_checkpoints_default` doesn't exists on CouchDB during first run.